### PR TITLE
[Testfix] Fix tier1 test case failures

### DIFF
--- a/tests/functional/dht/test_brick_full_add_brick_rebalance.py
+++ b/tests/functional/dht/test_brick_full_add_brick_rebalance.py
@@ -79,10 +79,13 @@ class TestBrickFullAddBrickRebalance(GlusterBaseClass):
             while (subvols[find_hashed_subvol(subvols, "/", filename)[1]] ==
                    subvol):
                 filename = self._get_random_string()
-            ret, _, _ = g.run(self.mounts[0].client_system,
-                              "fallocate -l {}G {}/{}".format(
-                                  usable_size, self.mounts[0].mountpoint,
-                                  filename))
+            ret, _, err = g.run(self.mounts[0].client_system,
+                                "fallocate -l {}G {}/{}".format(
+                                    usable_size, self.mounts[0].mountpoint,
+                                    filename))
+            err_msg = 'fallocate: fallocate failed: No space left on device'
+            if ret and err == err_msg:
+                ret = 0
             self.assertFalse(ret, "Failed to fill disk to min free limit")
         g.log.info("Disk filled up to min free limit")
 

--- a/tests/functional/snapshot/test_snapshot_restore.py
+++ b/tests/functional/snapshot/test_snapshot_restore.py
@@ -93,7 +93,7 @@ class SnapRestore(GlusterBaseClass):
         tearDown
         """
         ret, _, _ = snap_delete_all(self.mnode)
-        if not ret:
+        if ret:
             raise ExecutionError("Snapshot delete failed.")
 
         # Unmount and cleanup-volume


### PR DESCRIPTION
Problems:
---------
test_self_heal_with_link_files.py fails as granular entry heal
creates a directory which causes aqreual-checksum mismatch.

test_brick_full_add_brick_rebalance.py fails with
`fallocate: fallocate failed: No space left on device` which
happens as the volume gets filled quicker than expected.

test_rebalance_add_brick_command.py fails with disperse volumes
as it runs `expand_volume()` till the bricks is exhausted.

test_snapshot_restore.py `if not ret` causes teardown failures
even when the command was successful.

Fixes:
------
test_self_heal_with_link_files.py - Update to support granualar entry heal.
test_brick_full_add_brick_rebalance.py - Modify code to not fail on I/O.
test_rebalance_add_brick_command.py - Modify code to not run expand_volume
4 times.
test_snapshot_restore.py - Change to `if ret` to fix tearDown failure

Signed-off-by: kshithijiyer <kshithij.ki@gmail.com>