### PR TITLE
[TestFix] Remove trigger_heal and change to tearDown in arbiter cases

### DIFF
--- a/tests/functional/arbiter/test_metadata_self_heal.py
+++ b/tests/functional/arbiter/test_metadata_self_heal.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2015-2020  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2015-2021 Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -30,7 +30,6 @@ from glustolibs.gluster.heal_libs import (monitor_heal_completion,
                                           is_heal_complete,
                                           is_volume_in_split_brain,
                                           is_shd_daemonized)
-from glustolibs.gluster.heal_ops import trigger_heal
 from glustolibs.misc.misc_libs import upload_scripts
 from glustolibs.io.utils import (collect_mounts_arequal,
                                  wait_for_io_to_complete)
@@ -300,11 +299,6 @@ class TestMetadataSelfHeal(GlusterBaseClass):
         ret = is_shd_daemonized(self.all_servers)
         self.assertTrue(ret, "Either No self heal daemon process found")
         g.log.info("All self-heal-daemons are online")
-
-        # Start healing
-        ret = trigger_heal(self.mnode, self.volname)
-        self.assertTrue(ret, 'Heal is not started')
-        g.log.info('Healing is started')
 
         # Monitor heal completion
         ret = monitor_heal_completion(self.mnode, self.volname)

--- a/tests/functional/arbiter/test_split_brain.py
+++ b/tests/functional/arbiter/test_split_brain.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2020  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2020-2021 Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -51,16 +51,15 @@ class TestSplitBrain(GlusterBaseClass):
         if not ret:
             raise ExecutionError("Failed to Setup_Volume and Mount_Volume")
 
-    @classmethod
-    def tearDownClass(cls):
+    def tearDown(self):
         """
         Cleanup Volume
         """
-        ret = cls.unmount_volume_and_cleanup_volume(cls.mounts)
+        ret = self.unmount_volume_and_cleanup_volume(self.mounts)
         if not ret:
-            raise ExecutionError("Failed to create volume")
+            raise ExecutionError("Failed to remove volume")
 
-        cls.get_super_method(cls, 'tearDownClass')()
+        self.get_super_method(self, 'tearDown')()
 
     def _bring_bricks_online(self):
         """


### PR DESCRIPTION
Problem:
-------
test_metadata_self_heal.py - trigger_heal() function call isn't needed
as heal is automatically triggered when shd is enabled back.
test_split_brain.py - Test case fails in tearDownClass() as
doCleanups() cleans up the setup before invoking tearDownClass().

Solution:
---------
test_metadata_self_heal.py - Removing trigger_heal() function call.
test_split_brain.py - Change tearDownClass() to tearDown().

Signed-off-by: kshithijiyer <kshithij.ki@gmail.com>