### PR TITLE
[LibFix] Removing getchildren from glustolibs as deprecated

### DIFF
--- a/glustolibs-gluster/glustolibs/gluster/heal_ops.py
+++ b/glustolibs-gluster/glustolibs/gluster/heal_ops.py
@@ -288,7 +288,7 @@ def get_heal_info(mnode, volname):
         brick_heal_info = {}
         brick_files_to_heal = []
         file_to_heal_exist = False
-        for element in brick.getchildren():
+        for element in brick:
             if element.tag == "file":
                 file_to_heal_exist = True
                 file_info = {}
@@ -374,7 +374,7 @@ def get_heal_info_split_brain(mnode, volname):
         brick_heal_info_split_brain = {}
         brick_files_in_split_brain = []
         is_file_in_split_brain = False
-        for element in brick.getchildren():
+        for element in brick:
             if element.tag == "file":
                 is_file_in_split_brain = True
                 file_info = {}

--- a/glustolibs-gluster/glustolibs/gluster/peer_ops.py
+++ b/glustolibs-gluster/glustolibs/gluster/peer_ops.py
@@ -290,10 +290,10 @@ def get_peer_status(mnode):
     peer_status_list = []
     for peer in root.findall("peerStatus/peer"):
         peer_dict = {}
-        for element in peer.getchildren():
+        for element in peer:
             if element.tag == "hostnames":
                 hostnames_list = []
-                for hostname in element.getchildren():
+                for hostname in element:
                     hostnames_list.append(hostname.text)
                 element.text = hostnames_list
             peer_dict[element.tag] = element.text
@@ -342,12 +342,12 @@ def get_pool_list(mnode):
     pool_list_list = []
     for peer in root.findall("peerStatus/peer"):
         peer_dict = {}
-        for element in peer.getchildren():
+        for element in peer:
             if element.tag == "hostname" and element.text == 'localhost':
                 element.text = mnode
             if element.tag == "hostnames":
                 hostnames_list = []
-                for hostname in element.getchildren():
+                for hostname in element:
                     hostnames_list.append(hostname.text)
                 element.text = hostnames_list
             peer_dict[element.tag] = element.text

--- a/glustolibs-gluster/glustolibs/gluster/profile_ops.py
+++ b/glustolibs-gluster/glustolibs/gluster/profile_ops.py
@@ -166,7 +166,7 @@ def get_profile_info(mnode, volname, options=''):
     volprofileinfo = {}
     volume = root.find("volProfile")
     brick_counter = 0
-    for elem in volume.getchildren():
+    for elem in volume:
         if elem.tag == "volname":
             volname = elem.text
             volprofileinfo[volname] = {}
@@ -174,10 +174,10 @@ def get_profile_info(mnode, volname, options=''):
             brick_counter += 1
             volprofileinfo[volname][elem.tag+str(brick_counter)] = {}
             brick_dict = volprofileinfo[volname][elem.tag+str(brick_counter)]
-            for brick_tag in elem.getchildren():
+            for brick_tag in elem:
                 if 'cumulativeStats' == brick_tag.tag:
                     brick_dict["cumulativeStats"] = {}
-                    for el in brick_tag.getchildren():
+                    for el in brick_tag:
                         if el.tag == 'duration':
                             brick_dict["cumulativeStats"][el.tag] = el.text
                         elif el.tag == 'totalWrite' or el.tag == 'totalRead':
@@ -186,25 +186,25 @@ def get_profile_info(mnode, volname, options=''):
                             brick_dict["cumulativeStats"][el.tag] = {}
                             block_dict = brick_dict["cumulativeStats"][el.tag]
                             counter = 0
-                            for block in el.getchildren():
+                            for block in el:
                                 counter += 1
                                 block_dict[block.tag+str(counter)] = {}
                                 elm_dict = block_dict[block.tag+str(counter)]
-                                for block_elm in block.getchildren():
+                                for block_elm in block:
                                     elm_dict[block_elm.tag] = block_elm.text
                         elif el.tag == 'fopStats':
                             brick_dict["cumulativeStats"][el.tag] = {}
                             fop_dict = brick_dict["cumulativeStats"][el.tag]
                             fop_count = 0
-                            for fops in el.getchildren():
+                            for fops in el:
                                 fop_dict['fop'+str(fop_count)] = {}
                                 fop_param = fop_dict['fop'+str(fop_count)]
-                                for fop in fops.getchildren():
+                                for fop in fops:
                                     fop_param[fop.tag] = fop.text
                                 fop_count += 1
                 elif 'intervalStats' == brick_tag.tag:
                     brick_dict["intervalStats"] = {}
-                    for el in brick_tag.getchildren():
+                    for el in brick_tag:
                         if el.tag == 'duration':
                             brick_dict["intervalStats"][el.tag] = el.text
                         elif el.tag == 'totalWrite' or el.tag == 'totalRead':
@@ -213,20 +213,20 @@ def get_profile_info(mnode, volname, options=''):
                             brick_dict["intervalStats"][el.tag] = {}
                             block_dict = brick_dict["intervalStats"][el.tag]
                             counter = 0
-                            for block in el.getchildren():
+                            for block in el:
                                 counter += 1
                                 block_dict[block.tag+str(counter)] = {}
                                 elm_dict = block_dict[block.tag+str(counter)]
-                                for block_elm in block.getchildren():
+                                for block_elm in block:
                                     elm_dict[block_elm.tag] = block_elm.text
                         elif el.tag == 'fopStats':
                             brick_dict["intervalStats"][el.tag] = {}
                             fop_dict = brick_dict["intervalStats"][el.tag]
                             fop_count = 0
-                            for fops in el.getchildren():
+                            for fops in el:
                                 fop_dict['fop'+str(fop_count)] = {}
                                 fop_param = fop_dict['fop'+str(fop_count)]
-                                for fop in fops.getchildren():
+                                for fop in fops:
                                     fop_param[fop.tag] = fop.text
                                 fop_count += 1
                 else:

--- a/glustolibs-gluster/glustolibs/gluster/quota_ops.py
+++ b/glustolibs-gluster/glustolibs/gluster/quota_ops.py
@@ -220,7 +220,7 @@ def quota_fetch_list(mnode, volname, path=None):
 
     quotalist = {}
     for path in root.findall("volQuota/limit"):
-        for elem in path.getchildren():
+        for elem in path:
             if elem.tag == "path":
                 path = elem.text
                 quotalist[path] = {}
@@ -315,7 +315,7 @@ def quota_fetch_list_objects(mnode, volname, path=None):
 
     quotalist = {}
     for path in root.findall("volQuota/limit"):
-        for elem in path.getchildren():
+        for elem in path:
             if elem.tag == "path":
                 path = elem.text
                 quotalist[path] = {}

--- a/glustolibs-gluster/glustolibs/gluster/rebalance_ops.py
+++ b/glustolibs-gluster/glustolibs/gluster/rebalance_ops.py
@@ -181,15 +181,15 @@ def get_rebalance_status(mnode, volname):
     rebal_status = {}
     rebal_status["node"] = []
     for info in root.findall("volRebalance"):
-        for element in info.getchildren():
+        for element in info:
             if element.tag == "node":
                 status_info = {}
-                for elmt in element.getchildren():
+                for elmt in element:
                     status_info[elmt.tag] = elmt.text
                 rebal_status[element.tag].append(status_info)
             elif element.tag == "aggregate":
                 status_info = {}
-                for elmt in element.getchildren():
+                for elmt in element:
                     status_info[elmt.tag] = elmt.text
                 rebal_status[element.tag] = status_info
             else:
@@ -247,15 +247,15 @@ def rebalance_stop_and_get_status(mnode, volname):
     rebal_status = {}
     rebal_status["node"] = []
     for info in root.findall("volRebalance"):
-        for element in info.getchildren():
+        for element in info:
             if element.tag == "node":
                 status_info = {}
-                for elmt in element.getchildren():
+                for elmt in element:
                     status_info[elmt.tag] = elmt.text
                 rebal_status[element.tag].append(status_info)
             elif element.tag == "aggregate":
                 status_info = {}
-                for elmt in element.getchildren():
+                for elmt in element:
                     status_info[elmt.tag] = elmt.text
                 rebal_status[element.tag] = status_info
             else:
@@ -387,15 +387,15 @@ def get_remove_brick_status(mnode, volname, bricks_list):
     remove_brick_status = {}
     remove_brick_status["node"] = []
     for info in root.findall("volRemoveBrick"):
-        for element in info.getchildren():
+        for element in info:
             if element.tag == "node":
                 status_info = {}
-                for elmt in element.getchildren():
+                for elmt in element:
                     status_info[elmt.tag] = elmt.text
                 remove_brick_status[element.tag].append(status_info)
             elif element.tag == "aggregate":
                 status_info = {}
-                for elmt in element.getchildren():
+                for elmt in element:
                     status_info[elmt.tag] = elmt.text
                 remove_brick_status[element.tag] = status_info
             else:

--- a/glustolibs-gluster/glustolibs/gluster/snap_ops.py
+++ b/glustolibs-gluster/glustolibs/gluster/snap_ops.py
@@ -247,14 +247,14 @@ def get_snap_status(mnode):
     snap_status_list = []
     for snap in root.findall("snapStatus/snapshots/snapshot"):
         snap_status = {}
-        for element in snap.getchildren():
+        for element in snap:
             if element.tag == "volume":
                 status = {}
                 status["brick"] = []
-                for elmt in element.getchildren():
+                for elmt in element:
                     if elmt.tag == "brick":
                         brick_info = {}
-                        for el in elmt.getchildren():
+                        for el in elmt:
                             brick_info[el.tag] = el.text
                         status["brick"].append(brick_info)
                     else:
@@ -404,13 +404,13 @@ def get_snap_info(mnode):
     snap_info_list = []
     for snap in root.findall("snapInfo/snapshots/snapshot"):
         snap_info = {}
-        for element in snap.getchildren():
+        for element in snap:
             if element.tag == "snapVolume":
                 info = {}
-                for elmt in element.getchildren():
+                for elmt in element:
                     if elmt.tag == "originVolume":
                         info["originVolume"] = {}
-                        for el in elmt.getchildren():
+                        for el in elmt:
                             info[elmt.tag][el.tag] = el.text
                     else:
                         info[elmt.tag] = elmt.text
@@ -496,10 +496,10 @@ def get_snap_info_by_volname(mnode, volname):
     snap_vol_info = {}
 
     for snap in root.findall("snapInfo"):
-        for element in snap.getchildren():
+        for element in snap:
             if element.tag == "originVolume":
                 info = {}
-                for elmt in element.getchildren():
+                for elmt in element:
                     info[elmt.tag] = elmt.text
                 snap_vol_info[element.tag] = info
             else:
@@ -508,13 +508,13 @@ def get_snap_info_by_volname(mnode, volname):
     snap_info_list = []
     for snap in root.findall("snapInfo/snapshots/snapshot"):
         snap_info = {}
-        for element in snap.getchildren():
+        for element in snap:
             if element.tag == "snapVolume":
                 info = {}
-                for elmt in element.getchildren():
+                for elmt in element:
                     if elmt.tag == "originVolume":
                         info["originVolume"] = {}
-                        for el in elmt.getchildren():
+                        for el in elmt:
                             info[elmt.tag][el.tag] = el.text
                     else:
                         info[elmt.tag] = elmt.text
@@ -664,14 +664,14 @@ def get_snap_config(mnode, volname=None):
     snap_config = {}
     for config in root.findall("snapConfig/systemConfig"):
         sys_config = {}
-        for element in config.getchildren():
+        for element in config:
             sys_config[element.tag] = element.text
     snap_config["systemConfig"] = sys_config
 
     volume_config = []
     for config in root.findall("snapConfig/volumeConfig/volume"):
         vol_config = {}
-        for element in config.getchildren():
+        for element in config:
             vol_config[element.tag] = element.text
 
         if volname is not None:

--- a/glustolibs-gluster/glustolibs/gluster/volume_libs.py
+++ b/glustolibs-gluster/glustolibs/gluster/volume_libs.py
@@ -1258,9 +1258,9 @@ def shrink_volume(mnode, volname, subvol_num=None, replica_num=None,
             return False
         remove_brick_aggregate_status = {}
         for info in root.findall("volRemoveBrick"):
-            for element in info.getchildren():
+            for element in info:
                 if element.tag == "aggregate":
-                    for elmt in element.getchildren():
+                    for elmt in element:
                         remove_brick_aggregate_status[elmt.tag] = elmt.text
         if "completed" in remove_brick_aggregate_status['statusStr']:
             _rc = True

--- a/glustolibs-gluster/glustolibs/gluster/volume_ops.py
+++ b/glustolibs-gluster/glustolibs/gluster/volume_ops.py
@@ -450,7 +450,7 @@ def get_volume_status(mnode, volname='all', service='', options=''):
                     tmp_dict2[node_name] = [tmp_dict3]
         else:
             elem_tag = []
-            for elem in volume.getchildren():
+            for elem in volume:
                 elem_tag.append(elem.tag)
             nodes = volume.findall("node")
 
@@ -704,19 +704,19 @@ def get_volume_info(mnode, volname='all', xfail=False):
     root = etree.XML(out)
     volinfo = {}
     for volume in root.findall("volInfo/volumes/volume"):
-        for elem in volume.getchildren():
+        for elem in volume:
             if elem.tag == "name":
                 volname = elem.text
                 volinfo[volname] = {}
             elif elem.tag == "bricks":
                 volinfo[volname]["bricks"] = {}
-                tag_list = [x.tag for x in elem.getchildren() if x]
+                tag_list = [x.tag for x in elem if x]
                 if 'brick' in tag_list:
                     volinfo[volname]["bricks"]["brick"] = []
-                for el in elem.getchildren():
+                for el in elem:
                     if el.tag == 'brick':
                         brick_info_dict = {}
-                        for elmt in el.getchildren():
+                        for elmt in el:
                             brick_info_dict[elmt.tag] = elmt.text
                         (volinfo[volname]["bricks"]["brick"].
                          append(brick_info_dict))
@@ -724,7 +724,7 @@ def get_volume_info(mnode, volname='all', xfail=False):
             elif elem.tag == "options":
                 volinfo[volname]["options"] = {}
                 for option in elem.findall("option"):
-                    for el in option.getchildren():
+                    for el in option:
                         if el.tag == "name":
                             opt = el.text
                         if el.tag == "value":


### PR DESCRIPTION
Removing getchildren() as it is deprecated from python 3.2.
Some of the OCS test cases are failing with python3.

Signed-off-by: Aditya Ramteke <aramteke@redhat.com>