### PR TITLE
[TestFix] Fix test_sosreport_interoperability.py

### DIFF
--- a/tests/functional/bvt/test_sosreport_interoperability.py
+++ b/tests/functional/bvt/test_sosreport_interoperability.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2020  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2020-2021  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -129,9 +129,10 @@ class ValidateSosreportBehavior(GlusterBaseClass):
             _ = get_dir_contents(self.servers[1], untardir, recursive=True)
             ret[after] = list(x.split(untar_dirpath, 1)[-1] for x in _)
             if before == gluster_contents_after_sos[2]:
-                self.assertTrue(bool(before == ret[after]), 'gluster '
-                                ' sosreport may be missing as they dont match '
-                                'with actual contents')
+                difference = set(before)-set(ret[after])
+                self.assertEqual(len(difference), 0,
+                                 'gluster sosreport may be missing as they '
+                                 'dont match with actual contents')
             else:
                 # Need this logic for var/log/glusterfs entries as rotated(.gz)
                 # logs are not collected by sos


### PR DESCRIPTION
Fixing the comaprison logic for dirs before SOS report
generation and after

Problem:
The current approach is using `==` operator for comparing
two lists. The issue happens when the lists are in different
order,
for e.g:
>>>a = [1,2,3]
>>>b = [1,3,2]
>>>a == b
False

The comparison returns False, whereas the content of the lists
are same.

Solution:

Use set() instead to ensure that the contents are similar,
E.g.
>>> set(a) - set(b)
set()

Signed-off-by: Pranav <prprakas@redhat.com>