### PR TITLE
[TestFix] Fix test_rebalance_with_add_brick_and_lookup

### DIFF
--- a/tests/functional/dht/test_rebalance_add_brick_and_lookup.py
+++ b/tests/functional/dht/test_rebalance_add_brick_and_lookup.py
@@ -96,8 +96,9 @@ class TestRebalanceWithAddBrickAndLookup(GlusterBaseClass):
         end_time = time()
         self.assertEqual(ret, 0, "Failed to do a lookup")
         time_taken = end_time - start_time
-        self.assertTrue(time_taken <= 4.4, "Lookup takes more time "
-                        "than the previously benchmarked value.")
+        # ToDo: Implement a better approach to get benchmark value
+        # self.assertTrue(time_taken <= 4.4, "Lookup takes more time "
+        #                 "than the previously benchmarked value.")
         g.log.info("Lookup took : %d seconds", time_taken)
 
     def tearDown(self):


### PR DESCRIPTION
Problem:
The current approach compares the lookup time with a
predetermined time of 4.4 secs (It took	4 seconds in
RHGS 3.5.2 and keeping a buffer of 10%). But this value
is machine is specific and vairies accordingly with
machines. For e.g, below are the time taken when executed
the above tests	locally

```
Glusterfs 49

Lookup took : 19 seconds (distributed)
Lookup took : 14 seconds (distributed-replicated)
Lookup took : 14 seconds (distributed-dispersed)
Lookup took : 14 seconds (distributed-arbiter)

Glusterfs 56.2

Lookup took : 15 seconds (distributed)
Lookup took : 10 seconds (distributed-replicated)
Lookup took : 13 seconds (distributed-dispersed)
Lookup took : 11 seconds (distributed-arbiter)

Glusterfs 59

Lookup took : 15 seconds (distributed)
Lookup took : 10 seconds (distributed-replicated)
Lookup took : 13 seconds (distributed-dispersed)
Lookup took : 10 seconds (distributed-arbiter)

```

Solution:
The ideal way is to uninstall gluster rpms and install an
older version and run the lookup and finally compare the
results. But this approach is not feasible with our setup.
Hence removing the time comparison check until an efficient
approach is found

Signed-off-by: Pranav <prprakas@redhat.com>