### PR TITLE
[TestFix] Fix test_metadata_self_heal_on_open_fd

### DIFF
--- a/tests/functional/arbiter/test_metadata_self_heal_on_open_fd.py
+++ b/tests/functional/arbiter/test_metadata_self_heal_on_open_fd.py
@@ -16,7 +16,6 @@
 
 import os
 import copy
-from socket import gethostbyname
 from glusto.core import Glusto as g
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
@@ -174,13 +173,8 @@ class TestMetadataSelfHealOpenfd(GlusterBaseClass):
         bricks_list = []
         for brick in ret['brickdir_paths']:
             node, brick_path = brick.split(':')
-            if node[0:2].isdigit():
-                nodes_to_check[node] = os.path.dirname(brick_path)
-                path = node + ":" + os.path.dirname(brick_path)
-            else:
-                nodes_to_check[gethostbyname(node)] = (os.path.dirname(
-                    brick_path))
-                path = gethostbyname(node) + ":" + os.path.dirname(brick_path)
+            nodes_to_check[node] = os.path.dirname(brick_path)
+            path = node + ":" + os.path.dirname(brick_path)
             bricks_list.append(path)
         nodes_to_check[client] = m_point
 


### PR DESCRIPTION
Problem:
Method "get_heal_info_summary" returns dict with 'hostnames' as
keys in CI env and in the test we are using 'bricks_list' items, which
contains ip addr for accessing the above dict. This causes the
test to fail with 'KeyError' in CI env

Solution:
Change the logic to append hostnames in 'bricks_list' instead of
ip addr

Signed-off-by: Pranav <prprakas@redhat.com>