### PR TITLE
[TestFix] Fix Arbiter test failures

### DIFF
--- a/tests/functional/arbiter/test_handling_data_split_brain_of_files_heal_command.py
+++ b/tests/functional/arbiter/test_handling_data_split_brain_of_files_heal_command.py
@@ -23,6 +23,7 @@ from glustolibs.gluster.brick_libs import (bring_bricks_offline,
                                            bring_bricks_online,
                                            are_bricks_offline,
                                            get_all_bricks)
+from glustolibs.gluster.heal_ops import enable_self_heal_daemon
 from glustolibs.gluster.heal_libs import (monitor_heal_completion,
                                           is_heal_complete,
                                           is_volume_in_split_brain)
@@ -321,6 +322,10 @@ class TestArbiterSelfHeal(GlusterBaseClass):
             g.log.info("Heal triggered for %s:%s",
                        mount_obj.client_system, mount_obj.mountpoint)
         g.log.info('Heal triggered for all mountpoints')
+
+        # Enable self-heal daemon
+        ret = enable_self_heal_daemon(self.mnode, self.volname)
+        self.assertTrue(ret, 'Successfully started self heal daemon')
 
         # Monitor heal completion
         ret = monitor_heal_completion(self.mnode, self.volname)


### PR DESCRIPTION
- Test description states to enable shd but misses it in steps
- Adding missing step based on description
- Tested locally and the heal is successful

Change-Id: I562a5f75bc9561b8f6b68e5a338af494aca3d150
Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>